### PR TITLE
Update aws.md

### DIFF
--- a/website/content/docs/v0.9/Cloud Platforms/aws.md
+++ b/website/content/docs/v0.9/Cloud Platforms/aws.md
@@ -215,7 +215,8 @@ aws elbv2 create-target-group \
     --name talos-aws-tutorial-tg \
     --protocol TCP \
     --port 6443 \
-    --vpc-id $VPC
+    --vpc-id $VPC \
+    --target-type ip
 ```
 
 Now, using the target group's ARN, and the **PrivateIpAddress** from the instances that you created :


### PR DESCRIPTION
When creating a target group, the default target type is by instance ID, not IP.
But we reference IPs in the next step....

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
